### PR TITLE
Move DC configuraion from nodeclass to controller

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/apis"
 	"github.com/pkg/errors"
+	"github.com/vmware/govmomi/find"
 	"k8s.io/client-go/kubernetes"
 
 	x "net/url"
@@ -57,8 +58,13 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 
 	folder := options.FromContext(ctx).VsphereFolder
 	clusterName := options.FromContext(ctx).ClusterName
+	dcName := options.FromContext(ctx).VsphereDC
+	findClient := find.NewFinder(vsphereClient, true)
+	lo.Must0(err, "creating vsphere finder")
+	dc, err := findClient.Datacenter(ctx, dcName)
+	lo.Must0(err, "finding datacenter")
 
-	finderProvider := finder.NewDefaultProvider(tagClient, vsphereClient, folder, clusterName)
+	finderProvider := finder.NewDefaultProvider(tagClient, vsphereClient, findClient, dc, folder, clusterName)
 	instanceProvider := instance.NewDefaultProvider(
 		inClusterClient,
 		finderProvider,

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -24,6 +24,7 @@ type Options struct {
 	VsphereUsername string
 	VspherePassword string
 	VsphereFolder   string
+	VsphereDC       string
 	VsphereInsecure bool
 	KubeDistro      string
 	KubeVersion     string
@@ -40,6 +41,7 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.VsphereUsername, "vsphere-username", env.WithDefaultString("GOVC_USERNAME", ""), "[REQUIRED] The vSphere username to use for the vSphere provider")
 	fs.StringVar(&o.VspherePassword, "vsphere-password", env.WithDefaultString("GOVC_PASSWORD", ""), "[REQUIRED] The vSphere password to use for the vSphere provider")
 	fs.StringVar(&o.VsphereFolder, "vsphere-path", env.WithDefaultString("VSPHERE_FOLDER", ""), "[REQUIRED] The vSphere path to use for the vSphere provider")
+	fs.StringVar(&o.VsphereDC, "vsphere-dc", env.WithDefaultString("VSPHERE_DC", ""), "[REQUIRED] The vSphere DC to use for the vSphere provider")
 	fs.BoolVar(&o.VsphereInsecure, "vsphere-insecure", env.WithDefaultBool("GOVC_INSECURE", false), "[REQUIRED] The vSphere insecure flag to use for the vSphere provider")
 }
 

--- a/pkg/providers/finder/common.go
+++ b/pkg/providers/finder/common.go
@@ -10,30 +10,15 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 )
 
-func (p *Provider) ResolveResourcePool(ctx context.Context, selector v1alpha1.ResPoolSelctorTerm, dc *object.Datacenter) (*object.ResourcePool, error) {
+func (p *Provider) ResolveResourcePool(ctx context.Context, selector v1alpha1.ResPoolSelctorTerm) (*object.ResourcePool, error) {
 	if len(selector.Tags) > 0 {
 		return p.PoolByTag(ctx, selector.Tags)
 	}
 
 	if selector.Name != "" {
-		return p.PoolByName(ctx, selector.Name, dc)
+		return p.PoolByName(ctx, selector.Name)
 	}
 	return nil, fmt.Errorf("failed to resolve ResourcePool")
-}
-
-func (p *Provider) GetDC(ctx context.Context) (*object.Datacenter, error) {
-	return p.FindClient.DatacenterOrDefault(ctx, "*")
-
-}
-func (p *Provider) ResolveDC(ctx context.Context, selector v1alpha1.DCSelectorTerm) (*object.Datacenter, error) {
-	if len(selector.Tags) > 0 {
-		return p.DCByTag(ctx, selector.Tags)
-	}
-
-	if selector.Name != "" {
-		return p.DCByName(ctx, selector.Name)
-	}
-	return nil, fmt.Errorf("failed to resolve Datacenter")
 }
 
 func (p *Provider) ResolveDatastore(ctx context.Context, selector v1alpha1.DatastoreSelectorTerm) (*object.Datastore, error) {
@@ -82,26 +67,15 @@ func (p *Provider) isTemplate(ctx context.Context, obj *object.VirtualMachine) b
 }
 
 func (p *Provider) GetFolder(ctx context.Context, f string) (*object.Folder, error) {
-	dc, err := p.GetDC(ctx)
-	if err != nil {
-		return nil, err
-	}
-	p.FindClient.SetDatacenter(dc)
 	return p.FindClient.Folder(ctx, fmt.Sprintf("vm/%s", f))
 }
 
 func (p *Provider) ListVMs(ctx context.Context) ([]*object.VirtualMachine, error) {
-	dc, err := p.GetDC(ctx)
-	if err != nil {
-		return nil, err
-	}
-	p.FindClient.SetDatacenter(dc)
 	folder, err := p.GetFolder(ctx, p.Folder)
 	if err != nil {
 		return nil, err
 	}
 	vmPattern := fmt.Sprintf("%s/%s*", folder.InventoryPath, p.ClusterName)
-	// GetDC and list in given DC or all DCs
 	vms, err := p.FindClient.VirtualMachineList(ctx, vmPattern)
 	if err != nil {
 		if _, ok := err.(*find.NotFoundError); !ok {

--- a/pkg/providers/finder/name.go
+++ b/pkg/providers/finder/name.go
@@ -8,9 +8,9 @@ import (
 	corecloudprovider "sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
 
-func (p *Provider) PoolByName(ctx context.Context, name string, dc *object.Datacenter) (*object.ResourcePool, error) {
-	p.FindClient.SetDatacenter(dc)
-	poolPath := fmt.Sprintf("/%s/host/%s/Resources", dc.Name(), name)
+func (p *Provider) PoolByName(ctx context.Context, name string) (*object.ResourcePool, error) {
+
+	poolPath := fmt.Sprintf("host/%s/Resources", name)
 	pool, err := p.FindClient.ResourcePool(ctx, poolPath)
 	return pool, err
 }
@@ -24,27 +24,11 @@ func (p *Provider) NetworkByName(ctx context.Context, name string) (*object.Netw
 	return &network, err
 }
 
-func (p *Provider) DCByName(ctx context.Context, name string) (*object.Datacenter, error) {
-	dcPath := fmt.Sprintf("/%s", name)
-	return p.FindClient.Datacenter(ctx, dcPath)
-}
-
 func (p *Provider) VMByName(ctx context.Context, name string) (*object.VirtualMachine, error) {
-	dc, err := p.GetDC(ctx)
-	if err != nil {
-		return nil, err
-	}
-	p.FindClient.SetDatacenter(dc)
 	return p.FindClient.VirtualMachine(ctx, name)
 }
 
 func (p *Provider) ImageByPattern(ctx context.Context, pattern string) (*object.VirtualMachine, error) {
-	dc, err := p.GetDC(ctx)
-	if err != nil {
-		return nil, err
-	}
-	p.FindClient.SetDatacenter(dc)
-
 	vms, err := p.FindClient.VirtualMachineList(ctx, pattern)
 	if err != nil {
 		return nil, err
@@ -54,13 +38,8 @@ func (p *Provider) ImageByPattern(ctx context.Context, pattern string) (*object.
 
 func (p *Provider) GetVMByID(ctx context.Context, id string) (*object.VirtualMachine, error) {
 	ptrBool := false
-	dc, err := p.GetDC(ctx)
-	if err != nil {
-		return nil, err
-	}
-	//TODO: move to provider
-	searchIndex := object.NewSearchIndex(p.Client)
-	vmRef, err := searchIndex.FindByUuid(ctx, dc, id, true, &ptrBool)
+
+	vmRef, err := p.IndexClient.FindByUuid(ctx, p.DC, id, true, &ptrBool)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/providers/finder/tags.go
+++ b/pkg/providers/finder/tags.go
@@ -48,14 +48,6 @@ func (t *Provider) getObjectByTag(ctx context.Context, taglist map[string]string
 	return object.NewReference(t.Client, obj.Reference()), nil
 }
 
-func (t *Provider) DCByTag(ctx context.Context, tag map[string]string) (*object.Datacenter, error) {
-	ref, err := t.getObjectByTag(ctx, tag, "Datacenter")
-	if ref == nil {
-		return nil, fmt.Errorf("failed to get DC by Tag return is %v", ref)
-	}
-	return ref.(*object.Datacenter), err
-}
-
 func (t *Provider) PoolByTag(ctx context.Context, tag map[string]string) (*object.ResourcePool, error) {
 	ref, err := t.getObjectByTag(ctx, tag, "ClusterComputeResource")
 	if err != nil {

--- a/pkg/providers/finder/type.go
+++ b/pkg/providers/finder/type.go
@@ -11,12 +11,15 @@ type Provider struct {
 	TagManager  *tags.Manager
 	Client      *vim25.Client
 	IndexClient *object.SearchIndex
+	DC          *object.Datacenter
 	FindClient  *find.Finder
 	Folder      string
 	ClusterName string
 }
 
-func NewDefaultProvider(tMgr *tags.Manager, client *vim25.Client, folder, cluster string) *Provider {
+func NewDefaultProvider(tMgr *tags.Manager, client *vim25.Client, findClient *find.Finder, dc *object.Datacenter, folder, cluster string) *Provider {
 	idx := object.NewSearchIndex(client)
-	return &Provider{ClusterName: cluster, TagManager: tMgr, Client: client, IndexClient: idx, Folder: folder, FindClient: find.NewFinder(client, true)}
+	// Set Datacenter globally for find operations
+	findClient.SetDatacenter(dc)
+	return &Provider{ClusterName: cluster, TagManager: tMgr, Client: client, IndexClient: idx, Folder: folder, FindClient: findClient, DC: dc}
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -3,12 +3,13 @@ package instance
 import (
 	"context"
 	"fmt"
-	"github.com/absaoss/karpenter-provider-vsphere/pkg/operator/options"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"maps"
 	"strings"
 	"time"
+
+	"github.com/absaoss/karpenter-provider-vsphere/pkg/operator/options"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/vmware/govmomi/find"
 
@@ -51,7 +52,7 @@ func (p *DefaultProvider) Name() string {
 	return "vsphere"
 }
 
-func (p *DefaultProvider) GenerateVMSpec(ctx context.Context, class *v1alpha1.VsphereNodeClass, name string, instanceType *corecloudprovider.InstanceType) (*types.VirtualMachineCloneSpec, error) {
+func (p *DefaultProvider) GenerateVMSpec(ctx context.Context, class *v1alpha1.VsphereNodeClass, name string, image *object.VirtualMachine, instanceType *corecloudprovider.InstanceType) (*types.VirtualMachineCloneSpec, error) {
 	locationSpec, err := p.GenerateTarget(ctx, class)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate target for VM: %w", err)
@@ -62,10 +63,6 @@ func (p *DefaultProvider) GenerateVMSpec(ctx context.Context, class *v1alpha1.Vs
 		return nil, fmt.Errorf("failed to get device spec: %w", err)
 	}
 
-	image, err := p.Finder.ResolveImage(ctx, class.Spec.ImageSelector)
-	if err != nil {
-		return nil, err
-	}
 	t := time.Now()
 	return &types.VirtualMachineCloneSpec{
 		Template: false,
@@ -85,11 +82,7 @@ func (p *DefaultProvider) GenerateVMSpec(ctx context.Context, class *v1alpha1.Vs
 
 func (p *DefaultProvider) GenerateTarget(ctx context.Context, class *v1alpha1.VsphereNodeClass) (*types.VirtualMachineRelocateSpec, error) {
 	var relocationSpec types.VirtualMachineRelocateSpec
-	dc, err := p.Finder.ResolveDC(ctx, class.Spec.Datacenter)
-	if err != nil {
-		return nil, err
-	}
-	pool, err := p.Finder.ResolveResourcePool(ctx, class.Spec.PoolSelector, dc)
+	pool, err := p.Finder.ResolveResourcePool(ctx, class.Spec.PoolSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +141,8 @@ func (p *DefaultProvider) Create(
 	if err != nil {
 		return nil, fmt.Errorf("failed to find VM template: %w", err)
 	}
-	cloneSpec, err := p.GenerateVMSpec(ctx, class, VMName, instanceType)
+
+	cloneSpec, err := p.GenerateVMSpec(ctx, class, VMName, vmTemplate, instanceType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate VM spec: %w", err)
 	}


### PR DESCRIPTION
Multi DC machine spread is almost never used use case, move DC configuration into controller options.

* Ignore DC selector within nodeclass
* Lookup DC during initialization
* Make DC available within finder