### PR TITLE
refactor!: Add vsphere and kubeapi as chart values

### DIFF
--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -131,6 +131,20 @@ spec:
           {{- end }}
             - name: CLUSTER_NAME
               value: "{{ required "Chart cannot be installed without a valid settings.clusterName!" (tpl .Values.settings.clusterName .) }}"
+            - name: KUBE_DISTRO
+              value: "{{ required "Chart cannot be installed without a valid settings.kubeDistro!" (tpl .Values.settings.kubeDistro .) }}"
+            - name: CLUSTER_ENDPOINT
+              value: "{{ required "Chart cannot be installed without a valid settings.kubeApiAddress!" (tpl .Values.settings.kubeApiAddress .) }}"
+          {{- with .Values.settings.vsphereInsecure }}
+            - name: GOVC_INSECURE
+              value: "{{ . }}"
+          {{- end }}
+            - name: GOVC_URL
+              value: "{{ required "Chart cannot be installed without a valid settings.vsphereEndpoint!" (tpl .Values.settings.vsphereEndpoint .) }}"
+            - name: VSPHERE_FOLDER
+              value: "{{ required "Chart cannot be installed without a valid settings.vsphereFolder!" (tpl .Values.settings.vsphereFolder .) }}"
+            - name: VSPHERE_DC
+              value: "{{ required "Chart cannot be installed without a valid settings.vsphereDC!" (tpl .Values.settings.vsphereDC .) }}"
           {{- with .Values.controller.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -161,6 +161,18 @@ settings:
   preferencePolicy: Respect
   # -- Cluster name.
   clusterName: ""
+  # -- VSphere API endpoint
+  vsphereEndpoint: ""
+  # -- kubernetes distribution
+  kubeDistro: ""
+  # -- VSphere Insecure
+  vsphereInsecure: "false"
+  # -- VSphere Datacenter
+  vsphereDC: ""
+  # -- VSphere Folder
+  vsphereFolder: ""
+  # -- Kuberenteres API endpoint
+  kubeApiAddress: ""
   # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
   vmMemoryOverheadPercent: 0.075
 


### PR DESCRIPTION
Move core settings for vsphere and kubeApiAddress into `.Values.settings` so they can be overriden and validated as required values.