### PR TITLE
fix: re-authenticate vSphere session on expiry instead of failing with 401

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -5,25 +5,17 @@ import (
 	"time"
 
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/apis"
-	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/find"
 	"k8s.io/client-go/kubernetes"
-
-	x "net/url"
 
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/operator/options"
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/providers/finder"
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/providers/instance"
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/providers/kubernetesversion"
+	"github.com/absaoss/karpenter-provider-vsphere/pkg/providers/vsphereclient"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/samber/lo"
-	"github.com/vmware/govmomi"
-	"github.com/vmware/govmomi/session"
-	"github.com/vmware/govmomi/vapi/rest"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
-	"github.com/vmware/govmomi/vim25/soap"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/operator"
@@ -42,9 +34,14 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	vsphereClient, restClient, err := GetVsphereClient(ctx)
-	lo.Must0(err, "creating vsphere client")
-	tagClient := tags.NewManager(restClient)
+	vsClient, err := vsphereclient.NewSession(
+		ctx,
+		options.FromContext(ctx).VsphereEndpoint,
+		options.FromContext(ctx).VsphereUsername,
+		options.FromContext(ctx).VspherePassword,
+		options.FromContext(ctx).VsphereInsecure,
+	)
+	lo.Must0(err, "creating vsphere session")
 
 	//inClusterConfig := lo.Must(rest.InClusterConfig())
 	// for testing purposes load local kubeconfig if available
@@ -59,12 +56,11 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	folder := options.FromContext(ctx).VsphereFolder
 	clusterName := options.FromContext(ctx).ClusterName
 	dcName := options.FromContext(ctx).VsphereDC
-	findClient := find.NewFinder(vsphereClient, true)
-	lo.Must0(err, "creating vsphere finder")
+	findClient := find.NewFinder(vsClient.Vim, true)
 	dc, err := findClient.Datacenter(ctx, dcName)
 	lo.Must0(err, "finding datacenter")
 
-	finderProvider := finder.NewDefaultProvider(tagClient, vsphereClient, findClient, dc, folder, clusterName)
+	finderProvider := finder.NewDefaultProvider(vsClient, findClient, dc, folder, clusterName)
 	instanceProvider := instance.NewDefaultProvider(
 		inClusterClient,
 		finderProvider,
@@ -77,33 +73,4 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 		InstanceProvider:             instanceProvider,
 		FinderProvider:               finderProvider,
 	}
-}
-
-func GetVsphereClient(ctx context.Context) (*vim25.Client, *rest.Client, error) {
-	url := &x.URL{
-		Scheme: "https",
-		Host:   options.FromContext(ctx).VsphereEndpoint,
-		Path:   "/sdk",
-	}
-	soapClient := soap.NewClient(url, options.FromContext(ctx).VsphereInsecure)
-	url.User = x.UserPassword(options.FromContext(ctx).VsphereUsername, options.FromContext(ctx).VspherePassword)
-	vimClient, err := vim25.NewClient(ctx, soapClient)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to create vsphere client")
-	}
-	vimClient.UserAgent = "karpenter-vsphere"
-
-	c := &govmomi.Client{
-		Client:         vimClient,
-		SessionManager: session.NewManager(vimClient),
-	}
-	restClient := rest.NewClient(c.Client)
-	if err := c.Login(ctx, url.User); err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to create client: failed to login")
-	}
-	if err := restClient.Login(ctx, url.User); err != nil {
-		return nil, nil, errors.Wrapf(err, "failed to create client: failed to login to rest client")
-	}
-
-	return c.Client, restClient, nil
 }

--- a/pkg/providers/finder/name.go
+++ b/pkg/providers/finder/name.go
@@ -46,6 +46,6 @@ func (p *Provider) GetVMByID(ctx context.Context, id string) (*object.VirtualMac
 	if vmRef == nil {
 		return nil, corecloudprovider.NewNodeClaimNotFoundError(fmt.Errorf("vmRef not found"))
 	}
-	vm := object.NewVirtualMachine(p.Client, vmRef.Reference())
+	vm := object.NewVirtualMachine(p.Session.Vim, vmRef.Reference())
 	return vm, nil
 }

--- a/pkg/providers/finder/tags.go
+++ b/pkg/providers/finder/tags.go
@@ -14,7 +14,7 @@ import (
 func (t *Provider) getObjectByType(ctx context.Context, tags []*tags.Tag, objT string) (*types.ManagedObjectReference, error) {
 	objTagCount := map[types.ManagedObjectReference]int{}
 	for _, tag := range tags {
-		objs, err := t.TagManager.ListAttachedObjects(ctx, tag.ID)
+		objs, err := t.Session.Tags.ListAttachedObjects(ctx, tag.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -45,7 +45,7 @@ func (t *Provider) getObjectByTag(ctx context.Context, taglist map[string]string
 	if err != nil {
 		return nil, err
 	}
-	return object.NewReference(t.Client, obj.Reference()), nil
+	return object.NewReference(t.Session.Vim, obj.Reference()), nil
 }
 
 func (t *Provider) PoolByTag(ctx context.Context, tag map[string]string) (*object.ResourcePool, error) {
@@ -110,7 +110,7 @@ func (t *Provider) ImageByTag(ctx context.Context, tag map[string]string) (*obje
 }
 
 func (t *Provider) getTagID(ctx context.Context, k, v string) (*tags.Tag, error) {
-	return t.TagManager.GetTagForCategory(ctx, v, k)
+	return t.Session.Tags.GetTagForCategory(ctx, v, k)
 }
 
 func (t *Provider) TagInstance(ctx context.Context, obj types.ManagedObjectReference, tags map[string]string) error {
@@ -119,7 +119,7 @@ func (t *Provider) TagInstance(ctx context.Context, obj types.ManagedObjectRefer
 		return err
 	}
 	for _, tagID := range tagIDs {
-		err = t.TagManager.AttachTag(ctx, tagID, obj)
+		err = t.Session.Tags.AttachTag(ctx, tagID, obj)
 		if err != nil {
 			return err
 		}
@@ -148,10 +148,10 @@ func (t *Provider) CreateOrUpdateTags(ctx context.Context, instanceTags map[stri
 }
 
 func (t *Provider) CreateOrUpdateCategory(ctx context.Context, name string) (string, error) {
-	vsphereCategory, err := t.TagManager.GetCategory(ctx, name)
+	vsphereCategory, err := t.Session.Tags.GetCategory(ctx, name)
 	if err != nil {
 		fmt.Println("error getting vsphere category", err)
-		vsphereCategory, err := t.TagManager.CreateCategory(ctx, getCategoryObject(name))
+		vsphereCategory, err := t.Session.Tags.CreateCategory(ctx, getCategoryObject(name))
 		if err != nil {
 			return "", fmt.Errorf("failed to create vsphere category %s: %w", name, err)
 		}
@@ -161,10 +161,10 @@ func (t *Provider) CreateOrUpdateCategory(ctx context.Context, name string) (str
 }
 
 func (t *Provider) GetOrCreateTag(ctx context.Context, name, categoryID string) (string, error) {
-	tag, err := t.TagManager.GetTagForCategory(ctx, name, categoryID)
+	tag, err := t.Session.Tags.GetTagForCategory(ctx, name, categoryID)
 	if err != nil {
 		fmt.Println("error getting vsphere tag", err)
-		id, err := t.TagManager.CreateTag(ctx, &tags.Tag{
+		id, err := t.Session.Tags.CreateTag(ctx, &tags.Tag{
 			Description: "karpenter managed tag",
 			Name:        name,
 			CategoryID:  categoryID,
@@ -187,16 +187,16 @@ func getCategoryObject(name string) *tags.Category {
 }
 
 func (t *Provider) TagsFromVM(ctx context.Context, vm *object.VirtualMachine) (map[string]string, error) {
-	tagsAttached, err := t.TagManager.ListAttachedTags(ctx, vm.Reference())
+	tagsAttached, err := t.Session.Tags.ListAttachedTags(ctx, vm.Reference())
 	if err != nil {
 		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to list tags for VM %s", vm.Name()))
 	}
-	return extractTagInfo(ctx, t.TagManager, tagsAttached)
+	return extractTagInfo(ctx, t.Session.Tags, tagsAttached)
 
 }
 
 func extractTagInfo(ctx context.Context, tagManager *tags.Manager, tagIDs []string) (map[string]string, error) {
-	tags := make(map[string]string)
+	result := make(map[string]string)
 	for _, tagID := range tagIDs {
 		tag, err := tagManager.GetTag(ctx, tagID)
 		if err != nil {
@@ -210,8 +210,8 @@ func extractTagInfo(ctx context.Context, tagManager *tags.Manager, tagIDs []stri
 			// Normalize Vsphere tag to fulfill CPI requirements
 			cat.Name = corev1.LabelTopologyZone
 		}
-		tags[cat.Name] = tag.Name
+		result[cat.Name] = tag.Name
 	}
-	return tags, nil
+	return result, nil
 
 }

--- a/pkg/providers/finder/type.go
+++ b/pkg/providers/finder/type.go
@@ -1,15 +1,13 @@
 package finder
 
 import (
+	"github.com/absaoss/karpenter-provider-vsphere/pkg/providers/vsphereclient"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vapi/tags"
-	"github.com/vmware/govmomi/vim25"
 )
 
 type Provider struct {
-	TagManager  *tags.Manager
-	Client      *vim25.Client
+	Session     *vsphereclient.Session
 	IndexClient *object.SearchIndex
 	DC          *object.Datacenter
 	FindClient  *find.Finder
@@ -17,9 +15,9 @@ type Provider struct {
 	ClusterName string
 }
 
-func NewDefaultProvider(tMgr *tags.Manager, client *vim25.Client, findClient *find.Finder, dc *object.Datacenter, folder, cluster string) *Provider {
-	idx := object.NewSearchIndex(client)
+func NewDefaultProvider(session *vsphereclient.Session, findClient *find.Finder, dc *object.Datacenter, folder, cluster string) *Provider {
+	idx := object.NewSearchIndex(session.Vim)
 	// Set Datacenter globally for find operations
 	findClient.SetDatacenter(dc)
-	return &Provider{ClusterName: cluster, TagManager: tMgr, Client: client, IndexClient: idx, Folder: folder, FindClient: findClient, DC: dc}
+	return &Provider{ClusterName: cluster, Session: session, IndexClient: idx, Folder: folder, FindClient: findClient, DC: dc}
 }

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -110,6 +110,10 @@ func (p *DefaultProvider) Create(
 	claim *karpv1.NodeClaim,
 	instanceTypes []*corecloudprovider.InstanceType) (*Instance, error) {
 
+	if err := p.Finder.Session.EnsureValid(ctx); err == nil {
+		return nil, fmt.Errorf("failed to ensure vsphere session is valid: %w", err)
+	}
+
 	instanceType := instanceTypes[0] // For simplicity, we take the first instance type.
 	VMName := GenerateVMName(p.ClusterName, claim.Name)
 	instanceTags := map[string]string{
@@ -188,12 +192,15 @@ func (p *DefaultProvider) Create(
 		return nil, err
 	}
 
-	creationDate, err := extractCreationDate(ctx, vm)
+	creationDate, uuid, err := extractCreationDate(ctx, vm)
 	if err != nil {
 		return nil, err
 	}
 
 	powerOnTask, err := vm.PowerOn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to power on VM: %w", err)
+	}
 	err = powerOnTask.Wait(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("task failed: %w", err)
@@ -203,39 +210,49 @@ func (p *DefaultProvider) Create(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get power state: %w", err)
 	}
-	return NewInstance(vm, vm.UUID(ctx), vmTemplate.InventoryPath, string(powerState), vm.Name(), *creationDate, instanceTags), err
+	return NewInstance(vm, uuid, vmTemplate.InventoryPath, string(powerState), vm.Name(), *creationDate, instanceTags), err
 }
 
-func extractCreationDate(ctx context.Context, vm *object.VirtualMachine) (*time.Time, error) {
+// getVMConfig
+func getVMConfig(ctx context.Context, vm *object.VirtualMachine, properties []string) (*types.VirtualMachineConfigInfo, error) {
 	vmMo := models.VirtualMachine{
 		Config: &types.VirtualMachineConfigInfo{},
 	}
-	err := vm.Properties(ctx, vm.Reference(), []string{"config.createDate"}, &vmMo)
+	err := vm.Properties(ctx, vm.Reference(), properties, &vmMo)
 	if err != nil {
 		return nil, err
 	}
+	return vmMo.Config, nil
+}
 
-	t := vmMo.Config.CreateDate.UTC()
-	return &t, nil
+func extractCreationDate(ctx context.Context, vm *object.VirtualMachine) (*time.Time, string, error) {
+	config, err := getVMConfig(ctx, vm, []string{"config.createDate", "config.uuid"})
+	if err != nil {
+		return nil, "", err
+	}
+
+	t := config.CreateDate.UTC()
+	return &t, config.Uuid, nil
 }
 
 func GenerateVMName(cluster, claim string) string {
 	return fmt.Sprintf("%s-karp-%s", cluster, claim)
 }
 
-func getImageFromAnnotation(vm *object.VirtualMachine) string {
-	annotation := models.VirtualMachine{
-		Config: &types.VirtualMachineConfigInfo{},
-	}
-	err := vm.Properties(context.Background(), vm.Reference(), []string{"config.annotation"}, &annotation)
-	if err != nil && annotation.Config.Annotation == "" {
-		annotation.Config.Annotation = "image_not_found"
+func getImageFromAnnotation(ctx context.Context, vm *object.VirtualMachine) string {
+	config, err := getVMConfig(ctx, vm, []string{"config.annotation"})
+	if err != nil {
 		log.Log.Info(err.Error())
+		return "image_not_found"
 	}
-	return strings.TrimPrefix(annotation.Config.Annotation, "cloned_from:")
+	return strings.TrimPrefix(config.Annotation, "cloned_from:")
 }
 
 func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
+	if err := p.Finder.Session.EnsureValid(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure vsphere session is valid: %w", err)
+	}
+
 	instances := []*Instance{}
 	vms, err := p.Finder.ListVMs(ctx)
 	//
@@ -254,13 +271,13 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		if ps == "poweredOff" {
 			continue
 		}
-		image := getImageFromAnnotation(vm)
+		image := getImageFromAnnotation(ctx, vm)
 		tags, err := p.Finder.TagsFromVM(ctx, vm)
 		if err != nil {
 			log.FromContext(ctx).Error(err, fmt.Sprintf("failed to get tags for VM %s", vm.Name()))
 		}
 
-		creationDate, err := extractCreationDate(ctx, vm)
+		creationDate, uuid, err := extractCreationDate(ctx, vm)
 		if err != nil {
 			log.FromContext(ctx).Error(err, fmt.Sprintf("failed to extract creation date for VM %s", vm.Name()))
 		}
@@ -268,12 +285,16 @@ func (p *DefaultProvider) List(ctx context.Context) ([]*Instance, error) {
 		if tags["karpneter.sh/clustername"] != p.ClusterName {
 			continue
 		}
-		instances = append(instances, NewInstance(vm, vm.UUID(ctx), image, string(ps), vm.Name(), *creationDate, tags))
+		instances = append(instances, NewInstance(vm, uuid, image, string(ps), vm.Name(), *creationDate, tags))
 	}
 	return instances, nil
 }
 
 func (p *DefaultProvider) Get(ctx context.Context, vmID string) (*Instance, error) {
+	if err := p.Finder.Session.EnsureValid(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ensure vsphere session is valid: %w", err)
+	}
+
 	vm, err := p.Finder.GetVMByID(ctx, vmID)
 	if err != nil {
 		return nil, err
@@ -288,6 +309,10 @@ func (p *DefaultProvider) Get(ctx context.Context, vmID string) (*Instance, erro
 }
 
 func (p *DefaultProvider) Delete(ctx context.Context, vmID string) error {
+	if err := p.Finder.Session.EnsureValid(ctx); err != nil {
+		return fmt.Errorf("failed to ensure vsphere session is valid: %w", err)
+	}
+
 	i, err := p.Get(ctx, vmID)
 	if err != nil {
 		return err

--- a/pkg/providers/instance/instance_device_test.go
+++ b/pkg/providers/instance/instance_device_test.go
@@ -1,78 +1,78 @@
 package instance
 
 import (
-   "testing"
+	"testing"
 
-   "github.com/stretchr/testify/assert"
-   "github.com/vmware/govmomi/vim25/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func TestGetDiskConfigSpecResize(t *testing.T) {
-   tests := []struct {
-      name              string
-      templateDiskSize  int64
-      requestedDiskSize int64
-      expectError       bool
-      errorContains     string
-      expectedDiskSize  int64
-   }{
-      {
-         name:              "requested size less than template size should error",
-         templateDiskSize:  30,
-         requestedDiskSize: 20,
-         expectError:       true,
-         errorContains:     "can't resize template disk down",
-      },
-      {
-         name:              "requested size equal to template size",
-         templateDiskSize:  20,
-         requestedDiskSize: 20,
-         expectError:       false,
-         expectedDiskSize:  20,
-      },
-      {
-         name:              "requested size greater than template size",
-         templateDiskSize:  20,
-         requestedDiskSize: 40,
-         expectError:       false,
-         expectedDiskSize:  40,
-      },
-      {
-         name:              "zero requested size defaults to template size",
-         templateDiskSize:  25,
-         requestedDiskSize: 0,
-         expectError:       false,
-         expectedDiskSize:  25,
-      },
-   }
+	tests := []struct {
+		name              string
+		templateDiskSize  int64
+		requestedDiskSize int64
+		expectError       bool
+		errorContains     string
+		expectedDiskSize  int64
+	}{
+		{
+			name:              "requested size less than template size should error",
+			templateDiskSize:  30,
+			requestedDiskSize: 20,
+			expectError:       true,
+			errorContains:     "can't resize template disk down",
+		},
+		{
+			name:              "requested size equal to template size",
+			templateDiskSize:  20,
+			requestedDiskSize: 20,
+			expectError:       false,
+			expectedDiskSize:  20,
+		},
+		{
+			name:              "requested size greater than template size",
+			templateDiskSize:  20,
+			requestedDiskSize: 40,
+			expectError:       false,
+			expectedDiskSize:  40,
+		},
+		{
+			name:              "zero requested size defaults to template size",
+			templateDiskSize:  25,
+			requestedDiskSize: 0,
+			expectError:       false,
+			expectedDiskSize:  25,
+		},
+	}
 
-   for _, test := range tests {
-      t.Run(test.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 
-         disk := &types.VirtualDisk{
-            VirtualDevice: types.VirtualDevice{
-               Key: 2000,
-            },
-            CapacityInKB: test.templateDiskSize,
-         }
+			disk := &types.VirtualDisk{
+				VirtualDevice: types.VirtualDevice{
+					Key: 2000,
+				},
+				CapacityInKB: test.templateDiskSize,
+			}
 
-         result, err := getDiskConfigSpec(disk, test.requestedDiskSize)
+			result, err := getDiskConfigSpec(disk, test.requestedDiskSize)
 
-         if test.expectError {
-            assert.Error(t, err)
-            if test.errorContains != "" {
-               assert.Contains(t, err.Error(), test.errorContains)
-            }
-            return
-         }
-         assert.NoError(t, err)
-         assert.NotNil(t, result)
+			if test.expectError {
+				assert.Error(t, err)
+				if test.errorContains != "" {
+					assert.Contains(t, err.Error(), test.errorContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotNil(t, result)
 
-         spec := result.(*types.VirtualDeviceConfigSpec)
-         assert.Equal(t, types.VirtualDeviceConfigSpecOperationEdit, spec.Operation)
+			spec := result.(*types.VirtualDeviceConfigSpec)
+			assert.Equal(t, types.VirtualDeviceConfigSpecOperationEdit, spec.Operation)
 
-         resultDisk := spec.Device.(*types.VirtualDisk)
-         assert.Equal(t, test.expectedDiskSize, resultDisk.CapacityInKB)
-      })
-   }
+			resultDisk := spec.Device.(*types.VirtualDisk)
+			assert.Equal(t, test.expectedDiskSize, resultDisk.CapacityInKB)
+		})
+	}
 }

--- a/pkg/providers/instance/types.go
+++ b/pkg/providers/instance/types.go
@@ -6,6 +6,7 @@ import (
 
 	v1alpha1 "github.com/absaoss/karpenter-provider-vsphere/pkg/apis/v1alpha1"
 	"github.com/vmware/govmomi/object"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type Instance struct {
@@ -20,7 +21,14 @@ type Instance struct {
 }
 
 func NewInstanceFromVM(ctx context.Context, vm *object.VirtualMachine, created time.Time, tags map[string]string) *Instance {
-	instance := NewInstance(vm, vm.UUID(ctx), getImageFromAnnotation(vm), "", vm.Name(), created, tags)
+	config, err := getVMConfig(ctx, vm, []string{"config.uuid"})
+	uuid := ""
+	if err != nil {
+		log.Log.Info(err.Error())
+	} else {
+		uuid = config.Uuid
+	}
+	instance := NewInstance(vm, uuid, getImageFromAnnotation(ctx, vm), "", vm.Name(), created, tags)
 	return instance
 }
 func NewInstance(vm *object.VirtualMachine, id, image, state, name string, created time.Time, tags map[string]string) *Instance {

--- a/pkg/providers/kubernetesversion/kubernetesversion_test.go
+++ b/pkg/providers/kubernetesversion/kubernetesversion_test.go
@@ -3,14 +3,14 @@ package kubernetesversion
 import (
 	"context"
 
-	"testing"
-	"time"
 	"github.com/absaoss/karpenter-provider-vsphere/pkg/mocks"
 	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/version"
 	_ "k8s.io/client-go/kubernetes"
+	"testing"
+	"time"
 )
 
 func TestKubeServerVersions(t *testing.T) {

--- a/pkg/providers/vsphereclient/session.go
+++ b/pkg/providers/vsphereclient/session.go
@@ -1,0 +1,107 @@
+package vsphereclient
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sync"
+
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/session/cache"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vim25"
+)
+
+// Session holds long-lived vSphere SOAP and REST clients. vCenter can
+// invalidate their session at any time (idle timeout, vpxd restart, HA
+// failover, admin-configured absolute session caps, etc), so callers must
+// call EnsureValid once at the start of each unit of work (e.g. each
+// instance.Provider method) before using Vim/Rest/Tags -- mirroring how
+// cluster-api-provider-vsphere's session.GetOrCreate is called once per
+// controller Reconcile.
+type Session struct {
+	mu      sync.Mutex
+	session *cache.Session
+
+	Vim  *vim25.Client
+	Rest *rest.Client
+	Tags *tags.Manager
+}
+
+func NewSession(ctx context.Context, endpoint, username, password string, insecure bool) (*Session, error) {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   endpoint,
+		Path:   "/sdk",
+	}
+	u.User = url.UserPassword(username, password)
+
+	cs := &cache.Session{
+		URL:         u,
+		Insecure:    insecure,
+		Passthrough: true, // no file cache: controller runs with readOnlyRootFilesystem
+	}
+
+	s := &Session{
+		session: cs,
+		Vim:     &vim25.Client{},
+		Rest:    &rest.Client{},
+	}
+
+	if err := cs.Login(ctx, s.Vim, nil); err != nil {
+		return nil, fmt.Errorf("failed to create vsphere client: %w", err)
+	}
+	s.Vim.UserAgent = "karpenter-vsphere"
+
+	if err := cs.Login(ctx, s.Rest, nil); err != nil {
+		return nil, fmt.Errorf("failed to create vsphere rest client: %w", err)
+	}
+	s.Tags = tags.NewManager(s.Rest)
+
+	return s, nil
+}
+
+// EnsureValid checks whether the SOAP and REST sessions are still
+// authenticated against vCenter, and transparently re-authenticates
+func (s *Session) EnsureValid(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	valid, err := vimSessionValid(ctx, s.Vim)
+	if err != nil {
+		return fmt.Errorf("checking vsphere session: %w", err)
+	}
+	if !valid {
+		if err := s.session.Login(ctx, s.Vim, nil); err != nil {
+			return fmt.Errorf("failed to re-authenticate vsphere session: %w", err)
+		}
+	}
+
+	valid, err = restSessionValid(ctx, s.Rest)
+	if err != nil {
+		return fmt.Errorf("checking vsphere rest session: %w", err)
+	}
+	if !valid {
+		if err := s.session.Login(ctx, s.Rest, nil); err != nil {
+			return fmt.Errorf("failed to re-authenticate vsphere rest session: %w", err)
+		}
+	}
+	return nil
+}
+
+func vimSessionValid(ctx context.Context, client *vim25.Client) (bool, error) {
+	u, err := session.NewManager(client).UserSession(ctx)
+	if err != nil {
+		return false, err
+	}
+	return u != nil, nil
+}
+
+func restSessionValid(ctx context.Context, client *rest.Client) (bool, error) {
+	u, err := client.Session(ctx)
+	if err != nil {
+		return false, err
+	}
+	return u != nil, nil
+}


### PR DESCRIPTION
Introduce vsphereclient wrapping govmomi's session/cache with CallSOAP/CallREST helpers that detect an expired session and transparently re-login.